### PR TITLE
fix: use memmove instead of strcpy for overlapping memory

### DIFF
--- a/ntripcaster/src/ntrip_string.c
+++ b/ntripcaster/src/ntrip_string.c
@@ -120,7 +120,7 @@ splitc (char *first, char *rest, const char divider)
 
 	*p = 0;
 	if (first != NULL) strcpy(first, rest);
-	if (first != rest) strcpy(rest, p + 1);
+	if (first != rest) memmove(rest, p + 1, strlen(p + 1) + 1);
 
 	return rest;
 }


### PR DESCRIPTION
Currently `splitc` splits the string in-place by finding the delimiter and then calling `strcpy(rest, p + 1)`. `p` however points into the same buffer as `rest`, which is undefined behavior for `strcpy`. So if `first != rest` and the source/dest regions overlap, this call ends up potentially corrupting the data.

E.g. consider the following:

```c
#include <stdio.h>
#include <string.h>

#define BUFSIZE 1000

#define CONFIG_LINE                                  \
  "/mountpoint:alice:AAAA1111AAAA,bob:BBBB2222BBBB," \
  "carol:CCCC3333CCCC,dave:DDDD4444DDDD,eve:EEEE5555EEEE"

char* splitc(char* first, char* rest, const char divider) {
  char* p;

  if (!rest) {
    return NULL;
  }

  p = strchr(rest, divider);
  if (p == NULL) {
    if ((first != rest) && (first != NULL)) first[0] = 0;

    return NULL;
  }

  *p = 0;
  if (first != NULL) strcpy(first, rest);
  if (first != rest) strcpy(rest, p + 1);

  return rest;
}

int main(void) {
  char line[BUFSIZE], first[BUFSIZE];

  strcpy(line, CONFIG_LINE);

  /* like create_mount_from_line */
  splitc(first, line, ':');

  while (splitc(first, line, ',')) {
    printf("  %s\n", first);
  }

  printf("  %s\n", line);
  return 0;
}
```

Running `gcc -o /tmp/splitc_bug file_above.c && /tmp/splitc_bug` gives us the wrong username/passwords:

```text
  alice:AAAA1111AAAA
  bob:BBBB2222BBBB
  carol:CCCC3333CCCC
  davEEEE5555EEE555
  eve:EEEE5555EEEE
```

This caused authentication issues for some of the accounts I created.